### PR TITLE
Bug fix for clearTemp()

### DIFF
--- a/lib/persistent_session.js
+++ b/lib/persistent_session.js
@@ -421,7 +421,7 @@ PersistentSession.prototype.clear = function _psClear(key, list) {
 // === CLEAR TEMP ===
 // clears all the temporary keys
 PersistentSession.prototype.clearTemp = function _psClearTemp() {
-  this.clear(undefined, _.keys(_.omit(this._dict.keys, this.psKeys, this.psaKeys)));
+  this.clear(undefined, _.keys(_.omit(this._dict.keys, _.keys(this.psKeys), _.keys(this.psaKeys))));
 };
 
 // === CLEAR PERSISTENT ===


### PR DESCRIPTION
_.omit expects key names to exclude, but objects were being passed instead, causing clearTemp() to over-delete and clear both persistent and auth sessions too.

This fixes that and produces the correct behavior.